### PR TITLE
Used 'babel-preset-es2015-loose' instead 'babel-preset-es2015' for IE8

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,13 @@ module.exports = function ( content ) {
 	var defaultLoaders = {
 		html: precompileLoaderPath + '!' + htmlLoaderPath,
 		css: 'style-loader!css-loader',
-		js: 'babel-loader?presets[]=es2015-loose&plugins[]=transform-runtime&comments=false'
+		js: 'babel-loader?' + JSON.stringify( {
+			presets: [
+				[ "es2015", { loose: true } ]
+			],
+			plugins: [ "transform-runtime" ],
+			comments: false
+		} )
 	};
 	var defaultLang = {
 		template: 'html',

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,7 @@ module.exports = function ( content ) {
 	var defaultLoaders = {
 		html: precompileLoaderPath + '!' + htmlLoaderPath,
 		css: 'style-loader!css-loader',
-		js: 'babel-loader?presets[]=es2015&plugins[]=transform-runtime&comments=false'
+		js: 'babel-loader?presets[]=es2015-loose&plugins[]=transform-runtime&comments=false'
 	};
 	var defaultLang = {
 		template: 'html',

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "babel-plugin-transform-runtime": "^6.9.0",
     "babel-loader": "^6.2.4",
     "babel-core": "^6.10.4",
-    "babel-preset-es2015": "^6.9.0"
+    "babel-preset-es2015-loose": "^8.0.0"
   },
   "devDependencies": {
     "eslint": "^3.15.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "babel-plugin-transform-runtime": "^6.9.0",
     "babel-loader": "^6.2.4",
     "babel-core": "^6.10.4",
-    "babel-preset-es2015-loose": "^8.0.0"
+    "babel-preset-es2015": "^6.9.0"
   },
   "devDependencies": {
     "eslint": "^3.15.0",


### PR DESCRIPTION
Used 'babel-preset-es2015-loose' instead 'babel-preset-es2015' to avoid 'Object.defineProperty', for IE8