### PR TITLE
add regularjs' option about babel

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,13 @@ module.exports = function ( content ) {
 	var defaultLoaders = {
 		html: precompileLoaderPath + '!' + htmlLoaderPath,
 		css: 'style-loader!css-loader',
-		js: 'babel-loader?presets[]=es2015-loose&plugins[]=transform-runtime&comments=false'
+		js: 'babel-loader?' + JSON.stringify( {
+			presets: [
+				[ "es2015", { loose: true } ]
+			],
+			plugins: [ "transform-runtime" ],
+			comments: false
+		} )
 	};
 	var defaultLang = {
 		template: 'html',

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,16 +20,19 @@ module.exports = function ( content ) {
 	var precompileLoaderPath = require.resolve( './precompile' );
 	// use modified html-loader
 	var htmlLoaderPath = require.resolve( './html-loader' );
+	var query = loaderUtils.parseQuery(this.query) || {};
+	var jsLoaderQuery = {
+		presets: [
+		  ["es2015", { loose: query.loose }]
+		],
+		plugins: ["transform-runtime"],
+		comments: false
+	}
+	
 	var defaultLoaders = {
 		html: precompileLoaderPath + '!' + htmlLoaderPath,
 		css: 'style-loader!css-loader',
-		js: 'babel-loader?' + JSON.stringify( {
-			presets: [
-				[ "es2015", { loose: true } ]
-			],
-			plugins: [ "transform-runtime" ],
-			comments: false
-		} )
+		js: 'babel-loader?' + JSON.stringify(jsLoaderQuery)
 	};
 	var defaultLang = {
 		template: 'html',

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,7 @@ module.exports = function ( content ) {
 	var defaultLoaders = {
 		html: precompileLoaderPath + '!' + htmlLoaderPath,
 		css: 'style-loader!css-loader',
-		js: 'babel-loader?presets[]=es2015&plugins[]=transform-runtime&comments=false'
+		js: 'babel-loader?presets[]=es2015-loose&plugins[]=transform-runtime&comments=false'
 	};
 	var defaultLang = {
 		template: 'html',

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,19 +20,16 @@ module.exports = function ( content ) {
 	var precompileLoaderPath = require.resolve( './precompile' );
 	// use modified html-loader
 	var htmlLoaderPath = require.resolve( './html-loader' );
-	var query = loaderUtils.parseQuery(this.query) || {};
-	var jsLoaderQuery = {
-		presets: [
-		  ["es2015", { loose: query.loose }]
-		],
-		plugins: ["transform-runtime"],
+	var babelOption = assign( {
+		presets: [ "es2015" ],
+		plugins: [ "transform-runtime" ],
 		comments: false
-	}
+	}, options.loaders.babel );
 	
 	var defaultLoaders = {
 		html: precompileLoaderPath + '!' + htmlLoaderPath,
 		css: 'style-loader!css-loader',
-		js: 'babel-loader?' + JSON.stringify(jsLoaderQuery)
+		js: 'babel-loader?' + JSON.stringify(babelOption)
 	};
 	var defaultLang = {
 		template: 'html',

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "babel-plugin-transform-runtime": "^6.9.0",
     "babel-loader": "^6.2.4",
     "babel-core": "^6.10.4",
-    "babel-preset-es2015": "^6.9.0"
+    "babel-preset-es2015-loose": "^8.0.0"
   },
   "devDependencies": {
     "eslint": "^3.15.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "babel-plugin-transform-runtime": "^6.9.0",
     "babel-loader": "^6.2.4",
     "babel-core": "^6.10.4",
-    "babel-preset-es2015-loose": "^8.0.0"
+    "babel-preset-es2015": "^6.9.0"
   },
   "devDependencies": {
     "eslint": "^3.15.0",


### PR DESCRIPTION
Maybe we can combine the regularjs' option in webpack.config.js with the default babel option in regular-loader, then we can configure babel.